### PR TITLE
References to the Develocity Build Validation Scripts repository are renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Once confirmed you will see the following message and you can close the browser 
 ---
 ## Downloading the Develocity Build Validation Scripts
 
-1. Open the [Develocity Build Validation Scripts installation instructions](https://github.com/gradle/gradle-enterprise-build-validation-scripts/blob/main/Gradle.md#installation)
+1. Open the [Develocity Build Validation Scripts installation instructions](https://github.com/gradle/develocity-build-validation-scripts/blob/main/Gradle.md#installation)
 
 2. Copy the installation command
 


### PR DESCRIPTION
> [!CAUTION]
> This PR is not to be merged until the renaming has taken place. This is currently scheduled to happen on Dec 17 during EMEA morning. Check https://github.com/gradle/develocity-build-validation-scripts to verify the current state.

This PR renames references to the old Develocity Build Validation Scripts repository name to https://github.com/gradle/develocity-build-validation-scripts